### PR TITLE
Add migration lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,91 @@ export async function down(client) {
 }
 ```
 
+---
+
+## Hooks
+
+You can define optional lifecycle hooks to run custom logic before, after, or when an error occurs during a migration. These hooks are defined in the `libsqlrc.js` file.
+
+### Available Hooks and Parameters
+
+| Hook Name                                  | Called When                                                                 |
+|--------------------------------------------|------------------------------------------------------------------------------|
+| `beforeMigration(action, name)`            | Before each migration is executed                                           |
+| `afterMigration(action, name, result)`     | After each migration is successfully executed                               |
+| `afterMigrations(action, names, results)`  | **Only** called after all migrations when using the `latest` command        |
+| `onError(action, name, error)`             | When a migration fails                                                      |
+
+### Hook Parameters
+
+#### `action` (`"up"` \| `"down"`)
+Indicates the direction of the migration:
+
+- `"up"`: applying a migration
+- `"down"`: rolling back a migration
+
+#### `name` (string)
+The full name of the migration file, including the timestamp prefix.  
+This is the name that has been generated using the `make` command, for example:
+
+```
+20240327102435_add-users-table
+```
+
+#### `result` (any | undefined)
+The result of the executed migration. This is the value returned by the migration function, if any.  
+If the function does not return a value, `result` will be `undefined`.
+
+#### `names` (string[])
+An array of all processed migration names (only used in `afterMigrations`).
+
+#### `results` (any[] | undefined[])
+An array of results returned by each migration (only used in `afterMigrations`).  
+If a migration does not return a value, the corresponding entry will be `undefined`.
+
+#### `error` (Error)
+The error object thrown during a failed migration.
+
+### Example
+
+```js
+// libsqlrc.js
+
+export default {
+   development: {
+     connection: {
+       url: "file:local.db"
+     },
+     migrations: {
+       directory: "my_migrations_directory"
+     },
+     hooks: {
+       beforeMigration: (action, name) => {
+         console.log(`[${action}] Starting migration: ${name}`);
+       },
+       afterMigration: (action, name, result) => {
+         console.log(`[${action}] Finished migration: ${name}`, result);
+       },
+       afterMigrations: (action, names, results) => {
+         console.log(`[${action}] All migrations completed via "latest":`);
+         names.forEach((name, i) => {
+           console.log(` - ${name}`, results[i]);
+         });
+       },
+       onError: (action, name, error) => {
+         console.error(`[${action}] Migration failed: ${name}`, error);
+       }
+     }
+   }
+  // ...
+};
+```
+
+> **Note:** All hooks are optional. If a hook is not defined, it will be skipped silently.
+
+---
+
+
 ### Run the next migration
 
 Run the next migration that has not yet been run.

--- a/src/cli/down.js
+++ b/src/cli/down.js
@@ -19,7 +19,25 @@ export default async function down() {
 
   if (migrations.completed) {
     const latest = migrations.completed[migrations.completed.length - 1];
-    await latest.down(client);
+
+    if (typeof config.hooks?.beforeMigration === 'function') {
+      await config.hooks.beforeMigration('down', latest.name);
+    }
+
+    let result;
+    try {
+      result = await latest.down(client);
+    }
+    catch (err) {
+      if (typeof config.hooks?.onError === 'function') {
+        config.hooks.onError('down', latest.name, err);
+      }
+      throw err;
+    }
+
+    if (typeof config.hooks?.afterMigration === 'function') {
+      await config.hooks.afterMigration('down', latest.name, result);
+    }
 
     await client.execute({
       sql: `

--- a/src/cli/latest.js
+++ b/src/cli/latest.js
@@ -21,8 +21,29 @@ export default async function latest() {
       ? migrations.completed[migrations.completed.length - 1].batch + 1
       : 1;
 
+    const results = [];
     for (const migration of migrations.pending) {
-      await migration.up(client);
+
+      if (typeof config.hooks?.beforeMigration === 'function') {
+        await config.hooks.beforeMigration('up', migration.name);
+      }
+
+      let result;
+      try {
+        result = await migration.up(client);
+        results.push(result);
+      }
+      catch (err) {
+        if (typeof config.hooks?.onError === 'function') {
+          config.hooks.onError('up', migration.name, err);
+        }
+        throw err;
+      }
+
+      if (typeof config.hooks?.afterMigration === 'function') {
+        await config.hooks.afterMigration('up', migration.name, result);
+      }
+
       await client.execute({
         sql: `
           INSERT INTO libsql_migrate (
@@ -40,14 +61,15 @@ export default async function latest() {
       });
     }
 
-    const names = migrations.pending
-      .map((migration) => migration.name)
-      .join(", ");
-
+    const names = migrations.pending.map((migration) => migration.name);
     const plural = migrations.pending.length !== 1;
 
+    if (typeof config.hooks?.afterMigrations === 'function') {
+      await config.hooks.afterMigrations('up', names, results);
+    }
+
     logger.info(
-      `Ran ${migrations.pending.length} migration${plural ? "s" : ""}: ${names}.`,
+      `Ran ${migrations.pending.length} migration${plural ? "s" : ""}: ${names.join(", ")}.`,
     );
   } else {
     logger.info("Database schema is up-to-date.");


### PR DESCRIPTION
Adds optional hooks to libsqlrc.js for customizing behavior during migrations:
- `beforeMigration(action, name)`
- `afterMigration(action, name, result)`
- `afterMigrations(action, names, results)` [only with "latest"]
- `onError(action, name, error)`

Hooks allow for logging, notifications, or other side effects. Results may be undefined if migrations return nothing.