### PR TITLE
fix: wrap libsql client to convert named parameters to positional

### DIFF
--- a/src/cli/down.js
+++ b/src/cli/down.js
@@ -1,5 +1,4 @@
-import { createClient } from "@libsql/client";
-import { getConfig, getMigrations, logger } from "../lib/index.js";
+import { createClient, getConfig, getMigrations, logger } from "../lib/index.js";
 
 /**
  * Finds and rolls back the latest migration that was run by checking the

--- a/src/cli/latest.js
+++ b/src/cli/latest.js
@@ -1,5 +1,4 @@
-import { createClient } from "@libsql/client";
-import { getConfig, getMigrations, logger } from "../lib/index.js";
+import { createClient, getConfig, getMigrations, logger } from "../lib/index.js";
 
 /**
  * Finds and runs all migrations that have not yet been run by checking the

--- a/src/cli/rollback.js
+++ b/src/cli/rollback.js
@@ -1,5 +1,4 @@
-import { createClient } from "@libsql/client";
-import { getConfig, getMigrations, logger } from "../lib/index.js";
+import { createClient, getConfig, getMigrations, logger } from "../lib/index.js";
 
 /**
  * Finds and rolls back the latest batch of migrations that was run by checking

--- a/src/cli/seedRun.js
+++ b/src/cli/seedRun.js
@@ -1,5 +1,4 @@
-import { createClient } from "@libsql/client";
-import { getConfig, getSeeds, logger } from "../lib/index.js";
+import { createClient, getConfig, getSeeds, logger } from "../lib/index.js";
 
 /**
  * Runs specified or all seed file(s).

--- a/src/cli/up.js
+++ b/src/cli/up.js
@@ -1,5 +1,4 @@
-import { createClient } from "@libsql/client";
-import { getConfig, getMigrations, logger } from "../lib/index.js";
+import { createClient, getConfig, getMigrations, logger } from "../lib/index.js";
 
 /**
  * Finds and runs the next migration that has not yet been run by checking the

--- a/src/lib/createClient.js
+++ b/src/lib/createClient.js
@@ -1,0 +1,112 @@
+import { createClient as _createClient } from "@libsql/client";
+
+/**
+ * Creates a wrapped libsql client that transparently converts named parameters
+ * to positional parameters, working around a known libsql bug when syncing through Turso.
+ * @param {Object} config - The connection configuration for the client.
+ * @returns {Object} The wrapped client.
+ */
+export default function createClient(config) {
+	const client = _createClient(config);
+
+	const originalExecute = client.execute.bind(client);
+	client.execute = (statement) => {
+		return originalExecute(normalizeStatement(statement));
+	};
+
+	const originalBatch = client.batch.bind(client);
+	client.batch = (statements) => {
+		const stmts = Array.isArray(statements) ? statements.map(normalizeStatement) : [normalizeStatement(statements)];
+		return originalBatch(stmts);
+	};
+
+	const originalTransaction = client.transaction.bind(client);
+	client.transaction = async (...args) => {
+		const tx = await originalTransaction(...args);
+
+		const txExecute = tx.execute.bind(tx);
+		const txBatch = tx.batch.bind(tx);
+
+		tx.execute = (statement) => txExecute(normalizeStatement(statement));
+
+		tx.batch = (statements) => {
+			const stmts = Array.isArray(statements) ? statements.map(normalizeStatement) : [normalizeStatement(statements)];
+			return txBatch(stmts);
+		};
+
+		return tx;
+	};
+
+	return client;
+}
+
+/**
+ * Infer binding prefix used in a statement from provided args.
+ * @param {string} sql
+ * @param {Object} args
+ * @returns {string} binding character ('$' | '@' | ':')
+ */
+const guessBindingCharacter = (sql, args) => {
+	for (const bindingChar of ['$', '@', ':']) {
+		if (Object.keys(args).every(arg => sql.includes(bindingChar + arg))) {
+			return bindingChar;
+		}
+	}
+	throw new Error('Could not identify binding character');
+};
+
+/**
+ * Convert a named-parameter statement into positional form for libsql.
+ * @param {{sql:string,args:Object}} param0
+ * @returns {{sql:string,args:any[]}}
+ */
+const convertToPositionalParams = ({ sql, args }) => {
+	const positionalParams = [];
+	const bindingCharacter = guessBindingCharacter(sql, args);
+	const matcher = new RegExp(`\\${bindingCharacter}([a-zA-Z_][a-zA-Z0-9_]*)`, 'g');
+
+	// Sanitize args - transform unsupported types to strings
+	for (const [key, value] of Object.entries(args)) {
+		if (value && typeof value === 'object') {
+			if (value instanceof Date) {
+				args[key] = value.toISOString();
+			}
+			else if (value.constructor === Object || value.constructor === Array) {
+				args[key] = JSON.stringify(value);
+			}
+			else if (typeof value.toString === 'function') {
+				args[key] = value.toString();
+			}
+			else {
+				console.warn(`Unsupported type for parameter ${key}: ${value.constructor.name}`);
+				args[key] = null;
+			}
+		}
+	}
+	
+	// Replace named parameters in the SQL with positional parameters (?)
+	const transformedSql = sql.replace(matcher, (_, paramName) => {
+		if (paramName in args) {
+			positionalParams.push(args[paramName]);
+			return '?';
+		}
+		throw new Error(`Parameter ${paramName} not found in args object`);
+	});
+
+	return {
+		sql: transformedSql,
+		args: positionalParams
+	};
+};
+
+/**
+ * Normalize statements to positional args when args are present.
+ * @param {string|{sql:string,args:Object}} stmt
+ * @returns {string|{sql:string,args:any[]}}
+ */
+const normalizeStatement = (stmt) => {
+	if (typeof stmt === 'object' && stmt !== null && typeof stmt.args === 'object' && !Array.isArray(stmt.args)) {
+		return convertToPositionalParams(stmt);
+	}
+	return stmt;
+};

--- a/src/lib/getMigrations.js
+++ b/src/lib/getMigrations.js
@@ -1,8 +1,7 @@
 import { readdir } from "fs/promises";
 import { join, parse } from "node:path";
 import { pathToFileURL } from "node:url";
-import { createClient } from "@libsql/client";
-import { getConfig, logger } from "./index.js";
+import { createClient, getConfig, logger } from "./index.js";
 
 /**
  * Represents a database migration.

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,4 @@
+export { default as createClient } from "./createClient.js";
 export { default as getConfig } from "./getConfig.js";
 export { default as getMigrations } from "./getMigrations.js";
 export { default as getSeeds } from "./getSeeds.js";


### PR DESCRIPTION
**Background:** `libsql` has a known bug where named parameters (e.g. `:name`, `$name`, `@name`) are not handled correctly.
**Reference:** https://github.com/tursodatabase/libsql/issues/2010

**Proposed Solution:**
This adds a `createClient` wrapper that transparently intercepts execute, batch, and transaction calls to convert named parameters into positional (?) form before they reach the driver. All consumers now import `createClient` from the lib barrel instead of directly from `@libsql/client`.
