### PR TITLE
Replace named with positional parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,20 @@
-name: Lint
+name: CI
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
 
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
-      - run: npm install
+          node-version: 22
+      - run: npm ci
       - run: npm run lint:eslint
+      - run: npm run lint:prettier
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libsql-migrate",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libsql-migrate",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libsql-migrate",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Database migration and seed management for libsql with configurable options.",
   "bin": {
     "libsql-migrate": "src/cli/index.js"

--- a/src/cli/down.js
+++ b/src/cli/down.js
@@ -41,9 +41,9 @@ export default async function down() {
     await client.execute({
       sql: `
         DELETE FROM libsql_migrate
-        WHERE       name = :name;
+        WHERE       name = ?;
       `,
-      args: { name: latest.name },
+      args: [latest.name],
     });
 
     logger.info(`Rolled back 1 migration: ${latest.name}.`);

--- a/src/cli/latest.js
+++ b/src/cli/latest.js
@@ -48,14 +48,11 @@ export default async function latest() {
             name,
             batch
           ) VALUES (
-            :name,
-            :batch
+            ?,
+            ?
           );
         `,
-        args: {
-          name: migration.name,
-          batch,
-        },
+        args: [migration.name, batch],
       });
     }
 

--- a/src/cli/rollback.js
+++ b/src/cli/rollback.js
@@ -48,11 +48,9 @@ export default async function rollback() {
       await client.execute({
         sql: `
           DELETE FROM libsql_migrate
-          WHERE       name = :name;
+          WHERE       name = ?;
         `,
-        args: {
-          name: migration.name,
-        },
+        args: [migration.name],
       });
     }
 

--- a/src/cli/up.js
+++ b/src/cli/up.js
@@ -46,14 +46,11 @@ export default async function up() {
           name,
           batch
         ) VALUES (
-          :name,
-          :batch
+          ?,
+          ?
         );
       `,
-      args: {
-        name: next.name,
-        batch: latest ? latest.batch + 1 : 1,
-      },
+      args: [next.name, latest ? latest.batch + 1 : 1],
     });
 
     logger.info(`Ran 1 migration: ${next.name}.`);

--- a/tests/cli/down.test.js
+++ b/tests/cli/down.test.js
@@ -76,7 +76,7 @@ describe("down", () => {
       return sql.includes("DELETE FROM libsql_migrate");
     });
     expect(deleteCall).toBeDefined();
-    expect(deleteCall[0].args.name).toBe("20240101000000_create_users");
+    expect(deleteCall[0].args[0]).toBe("20240101000000_create_users");
   });
 
   it("logs the rolled back migration name", async () => {

--- a/tests/cli/latest.test.js
+++ b/tests/cli/latest.test.js
@@ -76,8 +76,8 @@ describe("latest", () => {
       return sql.includes("INSERT INTO libsql_migrate");
     });
     expect(insertCalls).toHaveLength(2);
-    expect(insertCalls[0][0].args.batch).toBe(1);
-    expect(insertCalls[1][0].args.batch).toBe(1);
+    expect(insertCalls[0][0].args[1]).toBe(1);
+    expect(insertCalls[1][0].args[1]).toBe(1);
   });
 
   it("uses batch number incremented from last completed migration", async () => {
@@ -95,7 +95,7 @@ describe("latest", () => {
       const sql = typeof arg === "string" ? arg : arg?.sql ?? "";
       return sql.includes("INSERT INTO libsql_migrate");
     });
-    expect(insertCall[0].args.batch).toBe(4);
+    expect(insertCall[0].args[1]).toBe(4);
   });
 
   it("logs count and names of all migrations run", async () => {

--- a/tests/cli/up.test.js
+++ b/tests/cli/up.test.js
@@ -76,7 +76,7 @@ describe("up", () => {
       return sql.includes("INSERT INTO libsql_migrate");
     });
     expect(insertCall).toBeDefined();
-    expect(insertCall[0].args.batch).toBe(1);
+    expect(insertCall[0].args[1]).toBe(1);
   });
 
   it("uses batch number incremented from the last completed migration", async () => {
@@ -94,7 +94,7 @@ describe("up", () => {
       const sql = typeof arg === "string" ? arg : arg?.sql ?? "";
       return sql.includes("INSERT INTO libsql_migrate");
     });
-    expect(insertCall[0].args.batch).toBe(3);
+    expect(insertCall[0].args[1]).toBe(3);
   });
 
   it("logs the migration name after running", async () => {


### PR DESCRIPTION
Avoids the bug described in upstream library tursodatabase/libsql#2010. With less intrusion than a wrapper that extracts parameters and rewrites SQL as seen in #10.

This change means that all internal SQL commands performed by libsql-migrate should no longer fail with embedded replica due to the named parameter bug.

Turso users should still write their migrations using positional parameters until the upstream bug is fixed.